### PR TITLE
fix(): don't use export default in index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,4 +2,4 @@ import integrations from './integrations';
 import XwingListLoader from './XwingListLoader';
 import fetchList from './fetch-list';
 
-export default new XwingListLoader(integrations, fetchList);
+module.exports = new XwingListLoader(integrations, fetchList);


### PR DESCRIPTION
Apparently transpiling a ES6 default export will result in the module being exported under the `default` key, so one would need to do this:

```js
var xwingListLoader = require("xwing-list-loader").default;
```

Where what we actually want is this:

```js
var xwingListLoader = require("xwing-list-loader");
```
