### PR TITLE
Add support for Meta-Wing 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,20 @@ listLoader.load(url).then(
 
 ## Supported integrations
 
-A URL will be matched against the following endpoints (in order):
+URLs will be matched against the following endpoints (in order):
+
+Second Edition:
 
 1. [(Yet Another) Squad Builder 2](http://raithos.github.io/)
 2. Launch Bay Next ([Android](https://play.google.com/store/apps/details?id=com.launchbaynext&hl=en) / [iOS](https://apps.apple.com/us/app/launch-bay-next/id1422488966))
-3. [(Yet Another) Squad Builder](http://geordanr.github.io/xwing)
-4. [Voidstate](http://xwing-builder.co.uk/build)
-5. [Fab's Squadrons Generator](http://x-wing.fabpsb.net/)
-6. [Meta-Wing](http://meta-wing.com/)
+3. [Meta-Wing2](https://meta.listfortress.com/)
+
+First Edition:
+
+4. [(Yet Another) Squad Builder](http://geordanr.github.io/xwing)
+5. [Voidstate](http://xwing-builder.co.uk/build)
+6. [Fab's Squadrons Generator](http://x-wing.fabpsb.net/)
+7. [Meta-Wing](http://meta-wing.com/)
 
 ## License
 

--- a/lib/integrations/MetaWing2.js
+++ b/lib/integrations/MetaWing2.js
@@ -1,0 +1,17 @@
+class MetaWing {
+  constructor() {
+    this.regexp = /^(?:https?:\/\/)?meta.listfortress.com\/squadrons\/([0-9]*)/;
+  }
+
+  matches(input) {
+    return this.regexp.exec(input) !== null;
+  }
+
+  getXWSUrl(input) {
+    const matches = this.regexp.exec(input);
+    const id = matches[1];
+    return `https://meta.listfortress.com/squadrons/${id}.json`;
+  }
+}
+
+export default MetaWing;

--- a/lib/integrations/index.js
+++ b/lib/integrations/index.js
@@ -4,10 +4,12 @@ import YASB from './YASB';
 import Voidstate from './Voidstate';
 import Fabs from './Fabs';
 import MetaWing from './MetaWing';
+import MetaWing2 from './MetaWing2';
 
 export default [
   new YASB2(),
   new LaunchBayNext(),
+  new MetaWing2(),
   new YASB(),
   new Voidstate(),
   new Fabs(),

--- a/tests/integrations/MetaWing2.test.js
+++ b/tests/integrations/MetaWing2.test.js
@@ -1,0 +1,39 @@
+import MetaWing2 from '../../lib/integrations/MetaWing2';
+
+describe('#matches() matches all MetaWing2 urls', () => {
+  test('/squadrons/<id> url', () => {
+    const metawing2 = new MetaWing2();
+    const url = 'https://meta.listfortress.com/squadrons/123';
+
+    expect(metawing2.matches(url)).toBe(true);
+  });
+  test('/squadrons/<id>.json url', () => {
+    const metawing2 = new MetaWing2();
+    const url = 'https://meta.listfortress.com/squadrons/123.json';
+
+    expect(metawing2.matches(url)).toBe(true);
+  });
+  test('url without protocol', () => {
+    const metawing2 = new MetaWing2();
+    const url = 'meta.listfortress.com/squadrons/123';
+
+    expect(metawing2.matches(url)).toBe(true);
+  });
+});
+
+describe('#getXWSUrl() returns url to xws json', () => {
+  test('for /squadrons/<id> url', () => {
+    const metawing2 = new MetaWing2();
+    const url = 'https://meta.listfortress.com/squadrons/123';
+    const result = 'https://meta.listfortress.com/squadrons/123.json';
+
+    expect(metawing2.getXWSUrl(url)).toEqual(result);
+  });
+  test('for /squadrons/<id>.json url', () => {
+    const metawing2 = new MetaWing2();
+    const url = 'https://meta.listfortress.com/squadrons/123.json';
+    const result = 'https://meta.listfortress.com/squadrons/123.json';
+
+    expect(metawing2.getXWSUrl(url)).toEqual(result);
+  });
+});


### PR DESCRIPTION
This will add support for Meta-Wing2 urls: `https://meta.listfortress.com/squadrons/<id>`